### PR TITLE
Debian moves scls to the core package

### DIFF
--- a/scl/elasticsearch/elastic-http.conf
+++ b/scl/elasticsearch/elastic-http.conf
@@ -21,6 +21,7 @@
 #############################################################################
 
 @requires http
+@requires json-plugin
 
 block destination elasticsearch-http(
   url()

--- a/scl/snmptrap/snmptrapd-source.conf
+++ b/scl/snmptrap/snmptrapd-source.conf
@@ -20,7 +20,7 @@
 #
 #############################################################################
 
-@requires snmptrapd_parser
+@requires snmptrapd-parser
 
 block source snmptrap(
   filename()


### PR DESCRIPTION
I was very curious if an underscore/hyphen error caused kira to fail in https://github.com/syslog-ng/syslog-ng/pull/2979, and when I found out it is, I thought why not just send a patch and save you some time.

Also, I humbly added an additional patch that `elasticsearch-http()` should require json-plugin too.