### PR TITLE
dbld: add python2 apt packages to kira

### DIFF
--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -159,6 +159,8 @@ python-yaml                     [kira]
 python3-yaml                    [kira]
 systemd-sysv                    [kira]
 python-is-python2               [kira]
+python2-dev                     [kira]
+python2-dbg                     [kira]
 
 
 #############################################################################


### PR DESCRIPTION
With this, we can configure `syslog-ng` with `--with-python=2`.

```
  python                      : yes (pkg-config package: python2)
```

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>