### PR TITLE
lgtm: build bison 3.6.4

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -13,3 +13,7 @@ extraction:
       - export PATH=/usr/lib/jvm/java-8-openjdk-amd64/bin/:$PATH
       - export LD_LIBRARY_PATH=/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64/server:$LD_LIBRARY_PATH
       - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+
+      - cd /tmp && wget https://ftp.gnu.org/gnu/bison/bison-3.6.4.tar.gz && tar -xzf bison-3.6.4.tar.gz
+      - cd /tmp/bison-3.6.4 && ./configure --prefix=/tmp/bison && make all install
+      - export PATH=/tmp/bison/bin/:$PATH


### PR DESCRIPTION
LGTM is running on Ubuntu 19.10, which has bison 3.4.1.
We are depending on at least bison 3.4.2 version, so we need to buildit ourselves.

If LGTM upgrades their build environment to 20.04, we can remove this patch, as 20.04 has bison 3.5.1, which is enough for us.

Signed-off-by: Attila Szakacs <attila.szakacs@oneidentity.com>