### PR TITLE
fix broken fedora-32 image build

### DIFF
--- a/dbld/packages.manifest
+++ b/dbld/packages.manifest
@@ -90,6 +90,7 @@ python-dev                  [debian-stretch, debian-buster, ubuntu-xenial, ubunt
 python2-dev                 [debian-sid]
 python-devel                [centos, fedora]
 python3-devel               [fedora]
+python-unversioned-command  [fedora]
 python3-dev                 [ubuntu-focal]
 python-pip                      [centos, fedora, debian-stretch, debian-buster, ubuntu-trusty, ubuntu-xenial, ubuntu-bionic]
 python3-pip                     [debian, ubuntu]


### PR DESCRIPTION
For some reason, the `python-unversioned-command` doesn't get installed anymore in the docker environment.
This causes the `/usr/bin/python` file (symlink to python3) to be missing for `dbld/builddeps` `install_pip_packages` step,
which fails because of this, as it expects `python` binary even though with python3 installed.

Fedora states that the `python-unversioned-command` is recommended by python3 package.
https://fedoraproject.org/wiki/Changes/Python_means_Python3
> make python3 (instead of python2) recommend python-unversioned-command

rpm query in a fedora-32 docker container (base image for syslog-ng-fedora-32) show this too:
```
/usr/bin/python
python3-pip
python3-setuptools
```

Previous builds install `python-unversioned-command` as a weak dependency when `install_yum_packages` step is done.
See dockerhub build: https://hub.docker.com/repository/docker/balabit/syslog-ng-fedora-32/builds/8ad3ec0d-59a2-4f58-b85f-54e2f03925eb

An alternative fix for this issue is to expect `python3` command over `python` in `install_pip_packages`.
